### PR TITLE
Clean up `lint` badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 [build-badge]: https://github.com/yonatankarp/spring-starter/actions/workflows/build.yml/badge.svg
 [build-state]: https://github.com/yonatankarp/spring-starter/actions/workflows/build.yml
-[linter-badge]: https://github.com/yonatankarp/spring-starter/actions/workflows/linting.yml/badge.svg
-[linter-state]: https://github.com/yonatankarp/spring-starter/actions/workflows/linting.yml
 [codeql-badge]: https://github.com/yonatankarp/spring-starter/actions/workflows/codeql.yml/badge.svg
 [codeql-state]: https://github.com/yonatankarp/spring-starter/actions/workflows/codeql.yml
 
@@ -22,7 +20,7 @@
 
 | **Type**     | **Status**                                                                                                                                                                             |
 |--------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| CI pipelines | [![Build][build-badge]][build-state]  [![Linters][linter-badge]][linter-state]  [![CodeQL][codeql-badge]][codeql-state]                                                                |
+| CI pipelines | [![Build][build-badge]][build-state]  [![CodeQL][codeql-badge]][codeql-state]                                                                                                          |
 | Maintenance  | [![Quality Gate Status][quality-badge]][quality-state] [![Maintainability Rating][maintainability-badge]][maintainability-state] [![Technical Debt][tech-debt-badge]][tech-debt-state] |
 | Security     | [![Security Rating][security-badge]][security-state] [![Vulnerabilities][vulnerabilities-badge]][vulnerabilities-state]                                                                |
 | License      | [![License: MIT][license-badge]][license-link]                                                                                                                                         |


### PR DESCRIPTION

# Purpose

This commit cleans up the `linter` badge since it's already included in the `build` script

# Types of changes

- [ ] Bugfix
- [ ] Feature
- [x] Refactoring

# Checklist

- [ ] Documentation is updated
- [ ] No new tests are needed
