### PR TITLE
Remove `pull_request_target`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,6 @@ name: Continuous Integration
 on:
   pull_request:
     types: [ opened, synchronize, reopened, ready_for_review ]
-  pull_request_target:
-    types: [ opened, synchronize, reopened, ready_for_review ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.job }}-${{ github.ref }}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 
-coroutines = "1.8.1"
+coroutines = "1.8.0"
 jooqDockerPlugin = "0.3.12"
 jvmTarget = "21"
 kotlin = "2.0.0"


### PR DESCRIPTION


# Purpose

Removing `pull_request_target` from CI as it causes duplicate executions of the pipeline that are failing. This commit might cause dependabot to stop working, and require further investigation after the fact.

# Types of changes

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

# Checklist

- [ ] Documentation is updated
- [x] No new tests are needed
